### PR TITLE
Add React frontend and Node backend prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# Prototype
+# ILLUVRSE Prototype
+
+This repository provides a minimal prototype for the ILLUVRSE project.
+It includes a Node.js backend written in TypeScript and a React frontend
+also using TypeScript. Authentication and data storage rely on Supabase.
+
+## Structure
+
+- `backend/` – Express API with routes for authentication, user profiles, and missions.
+- `frontend/` – Vite + React application with pages for login, profile management, and missions.
+
+Both folders contain their own `package.json` with the dependencies required.
+Note that dependencies are **not installed** in this environment.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "ts-node src/index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "@supabase/supabase-js": "^2.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-node": "^10.0.0",
+    "@types/express": "^4.17.14"
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,16 @@
+import express from 'express';
+import authRoutes from './routes/auth';
+import profileRoutes from './routes/profile';
+import missionRoutes from './routes/missions';
+
+const app = express();
+app.use(express.json());
+
+app.use('/auth', authRoutes);
+app.use('/profiles', profileRoutes);
+app.use('/missions', missionRoutes);
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import { supabase } from '../services/supabaseClient';
+
+const router = Router();
+
+// User registration
+router.post('/register', async (req, res) => {
+  const { email, password } = req.body;
+  const { data, error } = await supabase.auth.signUp({ email, password });
+  if (error) return res.status(400).json({ error: error.message });
+  res.json({ user: data.user });
+});
+
+// User login
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) return res.status(400).json({ error: error.message });
+  res.json({ session: data.session, user: data.user });
+});
+
+export default router;

--- a/backend/src/routes/missions.ts
+++ b/backend/src/routes/missions.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import { supabase } from '../services/supabaseClient';
+
+const router = Router();
+
+// List missions
+router.get('/', async (_req, res) => {
+  const { data, error } = await supabase.from('missions').select('*');
+  if (error) return res.status(400).json({ error: error.message });
+  res.json(data);
+});
+
+// Create a mission
+router.post('/', async (req, res) => {
+  const { title, description, xp_reward } = req.body;
+  const { data, error } = await supabase
+    .from('missions')
+    .insert({ title, description, xp_reward })
+    .single();
+  if (error) return res.status(400).json({ error: error.message });
+  res.json(data);
+});
+
+export default router;

--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import { supabase } from '../services/supabaseClient';
+
+const router = Router();
+
+// Get user profile
+router.get('/:id', async (req, res) => {
+  const { id } = req.params;
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', id)
+    .single();
+  if (error) return res.status(400).json({ error: error.message });
+  res.json(data);
+});
+
+// Update avatar and xp
+router.put('/:id', async (req, res) => {
+  const { id } = req.params;
+  const { avatar_url, xp } = req.body;
+  const { data, error } = await supabase
+    .from('profiles')
+    .update({ avatar_url, xp })
+    .eq('id', id)
+    .single();
+  if (error) return res.status(400).json({ error: error.message });
+  res.json(data);
+});
+
+export default router;

--- a/backend/src/services/supabaseClient.ts
+++ b/backend/src/services/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL || '';
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || '';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ILLUVRSE Prototype</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "vite"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@supabase/supabase-js": "^2.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "vite": "^4.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0"
+  }
+}

--- a/frontend/src/components/AvatarSelector.tsx
+++ b/frontend/src/components/AvatarSelector.tsx
@@ -1,0 +1,21 @@
+interface AvatarSelectorProps {
+  avatars: string[];
+  value: string;
+  onChange: (avatar: string) => void;
+}
+
+export function AvatarSelector({ avatars, value, onChange }: AvatarSelectorProps) {
+  return (
+    <div>
+      {avatars.map((url) => (
+        <img
+          key={url}
+          src={url}
+          alt="avatar"
+          style={{ border: url === value ? '2px solid blue' : undefined, cursor: 'pointer', width: 50 }}
+          onClick={() => onChange(url)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { supabase } from '../services/supabaseClient';
+
+export function LoginForm({ onLogin }: { onLogin: () => void }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) setError(error.message);
+    else onLogin();
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+      <button type="submit">Login</button>
+      {error && <p>{error}</p>}
+    </form>
+  );
+}

--- a/frontend/src/components/ProfileView.tsx
+++ b/frontend/src/components/ProfileView.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../services/supabaseClient';
+import { AvatarSelector } from './AvatarSelector';
+
+export function ProfileView({ userId }: { userId: string }) {
+  const [profile, setProfile] = useState<{ id: string; avatar_url: string; xp: number } | null>(null);
+  const [avatars] = useState([
+    '/avatars/a.png',
+    '/avatars/b.png',
+    '/avatars/c.png'
+  ]);
+
+  useEffect(() => {
+    supabase.from('profiles').select('*').eq('id', userId).single().then(({ data }) => setProfile(data));
+  }, [userId]);
+
+  const updateProfile = async (avatar_url: string) => {
+    const { data } = await supabase.from('profiles').update({ avatar_url }).eq('id', userId).single();
+    setProfile(data);
+  };
+
+  if (!profile) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>XP: {profile.xp}</h2>
+      <AvatarSelector avatars={avatars} value={profile.avatar_url} onChange={updateProfile} />
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import LoginPage from './pages/LoginPage';
+import ProfilePage from './pages/ProfilePage';
+import MissionPage from './pages/MissionPage';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<LoginPage />} />
+        <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/missions" element={<MissionPage />} />
+      </Routes>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,7 @@
+import { useNavigate } from 'react-router-dom';
+import { LoginForm } from '../components/LoginForm';
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  return <LoginForm onLogin={() => navigate('/profile')} />;
+}

--- a/frontend/src/pages/MissionPage.tsx
+++ b/frontend/src/pages/MissionPage.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../services/supabaseClient';
+
+interface Mission {
+  id: string;
+  title: string;
+  description: string;
+  xp_reward: number;
+}
+
+export default function MissionPage() {
+  const [missions, setMissions] = useState<Mission[]>([]);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [xpReward, setXpReward] = useState(0);
+
+  useEffect(() => {
+    supabase.from('missions').select('*').then(({ data }) => setMissions(data || []));
+  }, []);
+
+  const createMission = async () => {
+    const { data } = await supabase.from('missions').insert({ title, description, xp_reward: xpReward }).single();
+    if (data) setMissions((m) => [...m, data]);
+  };
+
+  return (
+    <div>
+      <h2>Create Mission</h2>
+      <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title" />
+      <input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Description" />
+      <input type="number" value={xpReward} onChange={(e) => setXpReward(Number(e.target.value))} placeholder="XP Reward" />
+      <button onClick={createMission}>Create</button>
+      <h2>Available Missions</h2>
+      <ul>
+        {missions.map((m) => (
+          <li key={m.id}>{m.title} - {m.description} ({m.xp_reward} XP)</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../services/supabaseClient';
+import { ProfileView } from '../components/ProfileView';
+
+export default function ProfilePage() {
+  const [userId, setUserId] = useState<string | null>(null);
+  useEffect(() => {
+    const session = supabase.auth.session();
+    setUserId(session?.user.id || null);
+  }, []);
+  if (!userId) return <div>Please login</div>;
+  return <ProfileView userId={userId} />;
+}

--- a/frontend/src/services/supabaseClient.ts
+++ b/frontend/src/services/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
## Summary
- set up Express backend with TS
- add Supabase auth and profile routes
- create mission endpoints
- scaffold Vite React frontend with login, profile, and mission pages

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_b_687a96b44f58832e82bbec27e8472d9b